### PR TITLE
Issue #30 fix: content editor edit lesson

### DIFF
--- a/editor/question-ctrl.js
+++ b/editor/question-ctrl.js
@@ -45,8 +45,6 @@ angular.module('org.ekstep.question', ['org.ekstep.metadataform'])
 		} else {
 			$scope.showTemplates();
 		}
-		
-    EventBus.listeners['editor:form:success'] = undefined;
     ecEditor.addEventListener('editor:form:success', $scope.saveMetaData);
 	}
 	$scope.showTemplates = function() {


### PR DESCRIPTION
Fix for Below scenario, while editing lesson
• I create new question-set & added to the stage.
• Opened "edit details" of content to change the content icon.
• I change the content icon
• when I click on save, Its not working 