### PR TITLE
Issue #SB-8987, fix: Fix to support unordered evaluation in FTB

### DIFF
--- a/editor/question-ctrl.js
+++ b/editor/question-ctrl.js
@@ -23,10 +23,12 @@ angular.module('org.ekstep.question', ['org.ekstep.metadataform'])
     formElementId: '#questionMetaDataTemplate',
     metadataFormName: 'questionMetaDataTemplate'
 	};
-	$scope.questionData = {'max_score': 1};
-	$scope.questionData.isShuffleOption = false;
-	$scope.questionData.isPartialScore = true;
-	$scope.questionData.eval_unordered = false;
+	$scope.questionData = {
+    max_score: 1,
+    isShuffleOption: false,
+    isPartialScore: true,
+    evalUnordered: false
+  };
   $scope.templateIcons = [];
   _.each($scope.templatesType, function(template, key){
     var templateIconName = template.toLowerCase();
@@ -148,7 +150,7 @@ angular.module('org.ekstep.question', ['org.ekstep.metadataform'])
   $scope.setPreviewData = function () {
     var confData = {};
     var qObj = {
-      "config": '{"metadata":{"title":"question title","description":"question description","medium":"English"},"max_time":0,"max_score":' + $scope.questionData.max_score + ',"partial_scoring":' + $scope.questionData.isPartialScore + ',"isShuffleOption":' + $scope.questionData.isShuffleOption + ',"layout":' + JSON.stringify($scope.questionData.templateType) + ',"eval_unordered":' + $scope.questionData.eval_unordered + '}',
+      "config": '{"metadata":{"title":"question title","description":"question description","medium":"English"},"max_time":0,"max_score":' + $scope.questionData.max_score + ',"partial_scoring":' + $scope.questionData.isPartialScore + ',"isShuffleOption":' + $scope.questionData.isShuffleOption + ',"layout":' + JSON.stringify($scope.questionData.templateType) + ',"evalUnordered":' + $scope.questionData.evalUnordered + '}',
       "data": JSON.stringify($scope.questionCreationFormData),
       "id": "c943d0a907274471a0572e593eab49c2",
       "pluginId": $scope.selectedTemplatePluginData.plugin.id,
@@ -270,7 +272,7 @@ angular.module('org.ekstep.question', ['org.ekstep.metadataform'])
         var metadataObj = $scope.questionMetaData;    
         metadataObj.category = $scope.category;
         // TODO: questionCount should be sent from unit template controllers. Currently it is hardcoded to 1.
-        data.config = { "metadata": metadataObj, "max_time": 0, "max_score": $scope.questionData.max_score, "partial_scoring": $scope.questionData.isPartialScore, "layout": $scope.questionData.templateType, "isShuffleOption" : $scope.questionData.isShuffleOption, "questionCount": 1, "eval_unordered": $scope.questionData.eval_unordered};
+        data.config = { "metadata": metadataObj, "max_time": 0, "max_score": $scope.questionData.max_score, "partial_scoring": $scope.questionData.isPartialScore, "layout": $scope.questionData.templateType, "isShuffleOption" : $scope.questionData.isShuffleOption, "questionCount": 1, "evalUnordered": $scope.questionData.evalUnordered};
         data.media = $scope.questionCreationFormData.media;
         questionFormData.data = data;
         var metadata = {
@@ -376,7 +378,7 @@ angular.module('org.ekstep.question', ['org.ekstep.metadataform'])
   	$scope.questionData.isPartialScore = questionData1.data.config.partial_scoring;
   	$scope.questionData.gradeLevel = questionData1.data.config.metadata.gradeLevel;
   	$scope.questionData.isShuffleOption = questionData1.data.config.isShuffleOption;
-  	$scope.questionData.eval_unordered = questionData1.data.config.eval_unordered;
+  	$scope.questionData.evalUnordered = questionData1.data.config.evalUnordered;
   	$scope.category = questionData.category;
   	if (questionData1.data.config.metadata.concepts) {
   		$scope.Totalconcepts = questionData1.data.config.metadata.concepts.length;

--- a/editor/question-ctrl.js
+++ b/editor/question-ctrl.js
@@ -26,6 +26,7 @@ angular.module('org.ekstep.question', ['org.ekstep.metadataform'])
 	$scope.questionData = {'max_score': 1};
 	$scope.questionData.isShuffleOption = false;
 	$scope.questionData.isPartialScore = true;
+	$scope.questionData.eval_unordered = false;
   $scope.templateIcons = [];
   _.each($scope.templatesType, function(template, key){
     var templateIconName = template.toLowerCase();
@@ -147,7 +148,7 @@ angular.module('org.ekstep.question', ['org.ekstep.metadataform'])
   $scope.setPreviewData = function () {
     var confData = {};
     var qObj = {
-      "config": '{"metadata":{"title":"question title","description":"question description","medium":"English"},"max_time":0,"max_score":' + $scope.questionData.max_score + ',"partial_scoring":' + $scope.questionData.isPartialScore + ',"isShuffleOption":' + $scope.questionData.isShuffleOption + ',"layout":' + JSON.stringify($scope.questionData.templateType) + '}',
+      "config": '{"metadata":{"title":"question title","description":"question description","medium":"English"},"max_time":0,"max_score":' + $scope.questionData.max_score + ',"partial_scoring":' + $scope.questionData.isPartialScore + ',"isShuffleOption":' + $scope.questionData.isShuffleOption + ',"layout":' + JSON.stringify($scope.questionData.templateType) + ',"eval_unordered":' + $scope.questionData.eval_unordered + '}',
       "data": JSON.stringify($scope.questionCreationFormData),
       "id": "c943d0a907274471a0572e593eab49c2",
       "pluginId": $scope.selectedTemplatePluginData.plugin.id,
@@ -269,7 +270,7 @@ angular.module('org.ekstep.question', ['org.ekstep.metadataform'])
         var metadataObj = $scope.questionMetaData;    
         metadataObj.category = $scope.category;
         // TODO: questionCount should be sent from unit template controllers. Currently it is hardcoded to 1.
-        data.config = { "metadata": metadataObj, "max_time": 0, "max_score": $scope.questionData.max_score, "partial_scoring": $scope.questionData.isPartialScore, "layout": $scope.questionData.templateType, "isShuffleOption" : $scope.questionData.isShuffleOption, "questionCount": 1};
+        data.config = { "metadata": metadataObj, "max_time": 0, "max_score": $scope.questionData.max_score, "partial_scoring": $scope.questionData.isPartialScore, "layout": $scope.questionData.templateType, "isShuffleOption" : $scope.questionData.isShuffleOption, "questionCount": 1, "eval_unordered": $scope.questionData.eval_unordered};
         data.media = $scope.questionCreationFormData.media;
         questionFormData.data = data;
         var metadata = {
@@ -375,6 +376,7 @@ angular.module('org.ekstep.question', ['org.ekstep.metadataform'])
   	$scope.questionData.isPartialScore = questionData1.data.config.partial_scoring;
   	$scope.questionData.gradeLevel = questionData1.data.config.metadata.gradeLevel;
   	$scope.questionData.isShuffleOption = questionData1.data.config.isShuffleOption;
+  	$scope.questionData.eval_unordered = questionData1.data.config.eval_unordered;
   	$scope.category = questionData.category;
   	if (questionData1.data.config.metadata.concepts) {
   		$scope.Totalconcepts = questionData1.data.config.metadata.concepts.length;

--- a/editor/question.html
+++ b/editor/question.html
@@ -130,6 +130,13 @@
                             <input type="checkbox" ng-model="questionData.isPartialScore">
                             <label>&nbsp;</label>
                         </div>
+                        <div ng-if="selectedTemplatePluginData.plugin.id == 'org.ekstep.questionunit.ftb'">
+                            <div class="ui label qb-toggle-label">Unordered Evaluation</div>
+                            <div class="ui fluid toggle checkbox verticalcenter">
+                                <input type="checkbox" ng-model="questionData.eval_unordered">
+                                <label>&nbsp;</label>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/editor/question.html
+++ b/editor/question.html
@@ -133,7 +133,7 @@
                         <div ng-if="selectedTemplatePluginData.plugin.id == 'org.ekstep.questionunit.ftb'">
                             <div class="ui label qb-toggle-label">Unordered Evaluation</div>
                             <div class="ui fluid toggle checkbox verticalcenter">
-                                <input type="checkbox" ng-model="questionData.eval_unordered">
+                                <input type="checkbox" ng-model="questionData.evalUnordered">
                                 <label>&nbsp;</label>
                             </div>
                         </div>


### PR DESCRIPTION
This is to provide a hot-fix in FTB for the issue SB-8987 by allowing the creator to choose whether an ordered or unordered evaluation is needed for the question. The unordered evaluation is off by default.